### PR TITLE
Workaround: Clozure CL unable to load Sheeple

### DIFF
--- a/src/messages.lisp
+++ b/src/messages.lisp
@@ -80,6 +80,14 @@
   (print-unreadable-object (message stream :identity t)
     (format stream "MESSAGE ~S" (message-name message))))
 
+#+:ccl #-:ccl-1.8
+;; Work around a bug in certain Clozure CL versions where *PRINT-PPRINT-DISPATCH*
+;; is NIL by default, which upsets SET-PPRINT-DISPATCH.
+;;
+;; Ticket reference: http://trac.clozure.com/ccl/ticket/784
+(when (null *print-pprint-dispatch*)
+  (setq *print-pprint-dispatch* (copy-pprint-dispatch nil)))
+
 (set-pprint-dispatch 'message #'pprint-message)
 
 (define-print-object ((%message %message) :type nil)


### PR DESCRIPTION
Hi,

I just tried `quickload`ing Sheeple into Clozure CL 1.7, which failed when trying to load `messages.lisp`.  The problem seems to be related to a Clozure CL bug: http://trac.clozure.com/ccl/ticket/784

I've hacked around the problem without looking too closely at Sheeple's internals, particularly its coding style.  Therefore, while I hope you find this patch useful, you might (rightfully) see it as an abomination.  In that case, consider this a bug report or something. ;)

Best regards,
Matthias Benkard
