### PR TITLE
Fix building in SBCL 2.1.0

### DIFF
--- a/src/objects.lisp
+++ b/src/objects.lisp
@@ -376,7 +376,7 @@ This function has no high-level error checks and SHOULD NOT BE CALLED FROM USER 
   new-parents)
 
 (defun (setf object-metaobject) (new-metaobject object)
-  (funcall '(setf smop:object-metaobject) new-metaobject (%object-metaobject object) object))
+  (funcall #'(setf smop:object-metaobject) new-metaobject (%object-metaobject object) object))
 
 ;;; Inheritance predicates
 (defun parentp (maybe-parent child)

--- a/src/properties.lisp
+++ b/src/properties.lisp
@@ -52,8 +52,8 @@ is signaled."
 (defun (setf direct-property-value) (new-value object property-name &rest options)
   "Tries to set a direct property value for OBJECT. If it succeeds, returns T, otherwise NIL."
   (if (std-object-p object)
-      (apply '(setf std-direct-property-value) new-value object property-name options)
-      (apply '(setf smop:direct-property-value) new-value (object-metaobject object) object property-name options)))
+      (apply #'(setf std-direct-property-value) new-value object property-name options)
+      (apply #'(setf smop:direct-property-value) new-value (object-metaobject object) object property-name options)))
 (defun (setf std-direct-property-value) (new-value object property-name &rest options)
   (declare (ignore options))
   (awhen (property-position property-name object)
@@ -73,7 +73,7 @@ is signaled."
                               &key (reader nil readerp) (writer nil writerp) accessor)
   "Sets NEW-VALUE as the value of a direct-property belonging to OBJECT, named
 PROPERTY-NAME."
-  (flet ((maybe-set-prop () (apply '(setf direct-property-value) new-value object property-name options)))
+  (flet ((maybe-set-prop () (apply #'(setf direct-property-value) new-value object property-name options)))
     (or (maybe-set-prop)                                                 ; try to set it
         (progn (apply 'add-direct-property object property-name options) ; couldn't set it, try adding it
                (maybe-set-prop))                                         ; then try setting it again


### PR DESCRIPTION
This version of SBCL is more strict about function designators in `funcall` and `apply`, namely do not allow passing  the list `(setf foo)` as a function designator.

See https://bugs.launchpad.net/sbcl/+bug/310069 for more details